### PR TITLE
Add server to command jekyll

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ I use [Jekyll](http://jekyllrb.com/), a static generator in Ruby, to create this
 5. And finally run:
 
   ```sh
-  $ jekyll server
+  $ jekyll server --watch
   ```
 
 You'll have access to the website at `localhost:4000` :D


### PR DESCRIPTION
The jekyll command only lists the commands available. But do not start the server.

Look at this picture: 

![screenshot from 2014-09-23 23 52 27](https://cloud.githubusercontent.com/assets/4191734/4383300/60f36a92-439e-11e4-8a1f-2a90c6269ce8.png)
